### PR TITLE
Moves schedule to separate page

### DIFF
--- a/content/schedule.md
+++ b/content/schedule.md
@@ -1,0 +1,4 @@
+---
+title: Schedule
+type: schedule
+---

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -3,11 +3,8 @@ primary_button_link: "/#tickets"
 links:
   - name: About
     link: about/
-  # Removes schedule nav link as the current nav
-  # code doesn't render the link well. With PR#43,
-  # this will be fixed.
-  # - name: Schedule
-  #   link: "#schedule"
+  - name: Schedule
+    link: schedule/
   - name: CoC
     link: coc/
   - name: FAQ

--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -1,4 +1,6 @@
 live: true
+extend: 'Find the schedule and talks in the .Extend track 
+        <a class="text-decoration-none fw-bold  yellow-text white-hovertext" href="https://something">here</a>'
 data:
   -
     date: 17th Sept

--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -1,6 +1,6 @@
 live: true
-extend: 'Find the schedule and talks in the .Extend track 
-        <a class="text-decoration-none fw-bold  yellow-text white-hovertext" href="https://something">here</a>'
+extend: 'Find the schedule for Neurodiversity and experience sharing happening at
+        <a class="text-decoration-none fw-bold  yellow-text white-hovertext" href="https://in.pycon.org/blog/2021/neurodiversity-and-experience-sharing.html">Stage 5.</a>'
 data:
   -
     date: 17th Sept
@@ -21,7 +21,7 @@ data:
             speaker: Nabarun Pal
             type: workshop
             link: https://in.pycon.org/cfp/2021/proposals/make-your-cloud-native-python-applications-kubernetes-native~bmZqr/
-      
+
       - time: 14:30
         talks:
           - title: Break/Networking
@@ -33,9 +33,9 @@ data:
             speaker: Gajendra Deshpande
             type: workshop
             link: https://in.pycon.org/cfp/2021/proposals/indicnlp-natural-language-processing-for-indian-languages-using-python~egJZ3/
-          
+
           - title: Knowledge graph data modelling with TerminusDB
-            speaker: Cheuk Ting Ho 
+            speaker: Cheuk Ting Ho
             type: workshop
             link: https://in.pycon.org/cfp/2021/proposals/knowledge-graph-data-modelling-with-terminusdb~dJ6yP/
 
@@ -49,7 +49,7 @@ data:
     schedule:
       - time: 12:00
         talks:
-          - title: PyCon India 2021 Opening Address
+          - title: Day 1 Opening Address
             speaker: ''
             type: extra
             track: all
@@ -76,18 +76,24 @@ data:
             link: https://in.pycon.org/cfp/2021/proposals/electromechanical-platform-for-reinforcement-learning-research-and-evaluation~aOYyY/
             track: 2
 
-          - title: Panel Discussion 1
-            speaker: ''
+          - title: Who Begat Python? Knowing your Interpreter
+            speaker: Divya Goswami
             type: talk
-            link: ''
+            link: https://in.pycon.org/cfp/2021/proposals/who-begat-python-knowing-your-interpreter~axkG3/
             track: 3
+
+          - title: The File-Server
+            speaker: Vipin Kumar
+            type: talk
+            link: https://in.pycon.org/cfp/2021/proposals/the-file-server~b4xRV/
+            track: 4
 
       - time: 14:00
         talks:
-          - title: Python and the Inversion of Control
-            speaker: David Seddon 
+          - title: ExpEYES - A Python powered measurement device for hands-on science education
+            speaker: Jithin B P
             type: talk
-            link: https://in.pycon.org/cfp/2021/proposals/python-and-the-inversion-of-control~aM8jO/
+            link: https://in.pycon.org/cfp/2021/proposals/expeyes-a-python-powered-measurement-device-for-hands-on-science-education~e731r/
             track: 1
 
           - title: Writing your own Kubernetes operator and CRD in Python with kopf to enhance and harden your Kubernetes clusters
@@ -96,12 +102,19 @@ data:
             link: https://in.pycon.org/cfp/2021/proposals/writing-your-own-kubernetes-operator-and-crd-in-python-with-kopf-to-enhance-and-harden-your-kubernetes-clusters~azpvm/
             track: 2
 
-          - title: Panel Discussion 1
-            speaker: ''
+          - title: Type Check your Django app
+            speaker: Kracekumar Ramaraju
             type: talk
-            link: ''
+            link: https://in.pycon.org/cfp/2021/proposals/type-check-your-django-app~ejRql/
             track: 3
-      
+
+          - title: "Tensorflow For the Web : Converting Python Machine Learning Models to Javascript using TFJS Converter"
+            speaker: Shivay Lamba
+            type: talk
+            link: https://in.pycon.org/cfp/2021/proposals/tensorflow-for-the-web-converting-python-machine-learning-models-to-javascript-using-tfjs-converter~bYEWn/
+            track: 4
+
+
       - time: 14:30
         talks:
           - title: Break/Networking
@@ -110,27 +123,27 @@ data:
       - time: 15:30
         talks:
           - title: Writing Better Documentation for Developers
-            speaker: Meredydd Luff 
+            speaker: Meredydd Luff
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/writing-better-documentation-for-developers~epY8N/
             track: 1
 
-          - title: "Touches of Python in Prosthetic Vision : New Generation Computer vision"
-            speaker: Anustup Mukherjee
+          - title: Mon School - The Joy of Programming
+            speaker: Anand Chitipothu
             type: talk
-            link: https://in.pycon.org/cfp/2021/proposals/touches-of-python-in-prosthetic-vision-new-generation-computer-vision~e5yQv/
+            link: https://in.pycon.org/cfp/2021/proposals/mon-school-the-joy-of-programming~e0R8K/
             track: 2
 
-          - title: Who Begat Python? Knowing your Interpreter
-            speaker: Divya Goswami 
+          - title: CS Education - Panel
+            speaker: Prabhu Ramchandran, Prof. Shriram Krishnamurthi, Pramode C E, Ambika Joshi
             type: talk
-            link: https://in.pycon.org/cfp/2021/proposals/who-begat-python-knowing-your-interpreter~axkG3/
+            link: https://in.pycon.org/blog/2021/cs-education-panel-discussion.html
             track: 3
 
       - time: 16:00
         talks:
           - title: A haphazard journey to a generative art twitter bot with matplotlib
-            speaker: Gautam Sisodia 
+            speaker: Gautam Sisodia
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/a-haphazard-journey-to-a-generative-art-twitter-bot-with-matplotlib~eER80/
             track: 1
@@ -141,25 +154,26 @@ data:
             link: https://in.pycon.org/cfp/2021/proposals/on-device-ai-deep-learning-on-mobile-devices~ejRZl/
             track: 2
 
-          - title: Type Check your Django app
-            speaker: Kracekumar Ramaraju
+          - title: CS Education - Panel (Cont.)
+            speaker: Prabhu Ramchandran, Prof. Shriram Krishnamurthi, Pramode C E, Ambika Joshi
             type: talk
-            link: https://in.pycon.org/cfp/2021/proposals/type-check-your-django-app~ejRql/
+            link: https://in.pycon.org/blog/2021/cs-education-panel-discussion.html
             track: 3
+
 
       - time: 16:30
         talks:
-          - title: Panel Discussion 2
-            speaker: ''
+          - title: Python in Space - Curiosity Sparks
+            speaker: Arthur Scholz, Thomas Albin, Kazunori Akiyama, Andrew Chael
             type: panel
-            link: ''
+            link: https://in.pycon.org/blog/2021/python-in-space-panel-discussion.html
             track: all
-        
+
       - time: 17:30
         talks:
           - title: Break/Networking
             type: extra
-            track: all 
+            track: all
 
       - time: 18:00
         talks:
@@ -187,7 +201,15 @@ data:
             speaker:  Ngazetungue Muheue
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/bridge-the-tech-gap-using-python~b2k8N/
-            track: 3   
+            track: 3
+
+          - title: Insights Generation - Art to Science
+            speaker: Rajneet Kaur
+            type: talk
+            link: https://in.pycon.org/cfp/2021/proposals/insights-generation-art-to-science~axk6q/
+            track: 4
+
+
 
       - time: 19:00
         talks:
@@ -199,7 +221,7 @@ data:
 
       - time: 20:00
         talks:
-          - title: PyCon India 2021 Closing Address
+          - title: Day 1 Closing Address
             speaker: ''
             type: extra
             track: all
@@ -209,7 +231,7 @@ data:
     schedule:
       - time: 12:00
         talks:
-          - title: PyCon India 2021 Day 2 Opening Address
+          - title: Day 2 Opening Address
             speaker: ''
             type: extra
             track: all
@@ -231,16 +253,23 @@ data:
             track: 1
 
           - title: Visualisation & Underlined Psychology
-            speaker: sayantikabanik
+            speaker: Sayantika Banik
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/visualisation-underlined-psychology~bkR8E/
             track: 2
 
-          - title: ExpEYES - A Python powered measurement device for hands-on science education
-            speaker: jithin
+          - title: Python and the Inversion of Control
+            speaker: David Seddon
             type: talk
-            link: https://in.pycon.org/cfp/2021/proposals/expeyes-a-python-powered-measurement-device-for-hands-on-science-education~e731r/
+            link: https://in.pycon.org/cfp/2021/proposals/python-and-the-inversion-of-control~aM8jO/
             track: 3
+
+          - title: Fine Grained Image Classification with Bilinear-CNN's
+            speaker: Rajesh Bhat
+            type: talk
+            link: https://in.pycon.org/cfp/2021/proposals/fine-grained-image-classification-with-bilinear-cnns~dNkLp/
+            track: 4
+
 
       - time: 14:00
         talks:
@@ -261,7 +290,15 @@ data:
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/reducing-technical-debt-for-ml-platforms~bW6Pv/
             track: 3
-      
+
+          - title: Path to Pythonic
+            speaker: Tushar Sadhwani
+            type: talk
+            link: https://in.pycon.org/cfp/2021/proposals/path-to-pythonic~e9r1Z/
+            track: 4
+
+
+
       - time: 14:30
         talks:
           - title: Break/Networking
@@ -270,15 +307,15 @@ data:
       - time: 15:30
         talks:
           - title:  Exploring Network Clusters in Python
-            speaker: Anand S 
+            speaker: Anand S
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/exploring-network-clusters-in-python~e312O/
             track: 1
 
-          - title: Mon School - The Joy of Programming
-            speaker: Anand Chitipothu
+          - title:  Open Source as a Day Job Panel
+            speaker: Nabarun Pal
             type: talk
-            link: https://in.pycon.org/cfp/2021/proposals/mon-school-the-joy-of-programming~e0R8K/
+            link: ''
             track: 2
 
           - title: Hey, Python-Web-Community! What's going on?
@@ -286,6 +323,7 @@ data:
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/hey-python-web-community-whats-going-on~erkR4/
             track: 3
+
 
       - time: 16:00
         talks:
@@ -296,30 +334,37 @@ data:
             track: 1
 
           - title: "Financial Data Forecaster: Time Series Forecasting on Stock Prices and Indexes"
-            speaker: anshika rajiv 
+            speaker: Anshika Rajiv
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/financial-data-forecaster-time-series-forecasting-on-stock-prices-and-indexes~dwpVM/
             track: 2
 
           - title: Delivering successful API integrations with documentation-driven development
-            speaker:  Jose Haro Peralta 
+            speaker:  Jose Haro Peralta
             type: talk
             link: https://in.pycon.org/cfp/2021/proposals/delivering-successful-api-integrations-with-documentation-driven-development~dwpmM/
             track: 3
 
+          - title: No Code Platform powered by Python & Django
+            speaker: Bhagvan Kommadi
+            type: talk
+            link: https://in.pycon.org/cfp/2021/proposals/no-code-platform-powered-by-python-django~eXDQA/
+            track: 4
+
+
       - time: 16:30
         talks:
-          - title: Panel Discussion 2
-            speaker: ''
+          - title: Diversity in Cybersecurity
+            speaker: Vandana Verma, Shira Shamban, Hitesh Dharmdasani, Judy Ngure
             type: panel
-            link: ''
+            link: https://in.pycon.org/blog/2021/diversity-in-cybersecurity-panel-discussion.html
             track: all
-        
+
       - time: 17:30
         talks:
           - title: Break/Networking
             type: extra
-            track: all 
+            track: all
 
       - time: 18:00
         talks:
@@ -349,6 +394,13 @@ data:
             link: https://in.pycon.org/cfp/2021/proposals/the-pit-of-success-for-object-level-permissions-in-django-how-to-make-it-easy-to-get-privacy-right~eVOAW/
             track: 3
 
+          - title: Building GraphQL APIs with Ariadne - a schema first approach
+            speaker: Rashmi K A
+            type: talk
+            link: https://in.pycon.org/cfp/2021/proposals/building-graphql-apis-with-ariadne-a-schema-first-approach~aKr8Y/
+            track: 4
+
+
       - time: 19:00
         talks:
           - title: Keynote
@@ -359,7 +411,7 @@ data:
 
       - time: 20:00
         talks:
-          - title: PyCon India 2021 Day 2 Closing Address
+          - title: Day 2 Closing Address
             speaker: ''
             type: extra
             track: all

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,10 +15,6 @@
         {{ partial "sections/ticket.html" (dict "tickets" .Site.Data.tickets.data) }}
     {{ end }}
 
-    <!-- Schedule -->
-    {{ if .Site.Data.schedule.live }}
-        {{ partial "sections/schedule.html" (dict "schedules" .Site.Data.schedule.data) }}
-    {{ end }}
 
     <!-- Outreach Partners -->
     {{ if .Site.Data.communities.live }}

--- a/layouts/partials/sections/schedule.html
+++ b/layouts/partials/sections/schedule.html
@@ -8,7 +8,7 @@
               <p class="schedule-para text-grey pt-md-3">All the times mentioned in the schedule are in Indian
                   Standard time (IST) timezone.</p>
               <!--a href="" class="yellow-text white-hovertext text-decoration-none fw-bold">Download <i
-                      class="fas fa-arrow-circle-down"></i></a>
+                      class="fas fa-arrow-circle-down"></i></a> -->
 
               <!-- tabs -->
               <div class="tab-sec mt-5">
@@ -32,9 +32,25 @@
                               {{ range $i, $elem := .schedule }}
                               <div class="row event {{ if (ne $i 0) }}mt-2{{ end }}" data-date="{{ .time }}">
                                   {{ range .talks }}
-                                    {{ if (or (eq .type "talk") (eq .type "workshop")) }}
+                                    {{ if (eq .type "workshop") }}
                                       <div
                                           class="col-lg-4 col-12 ps-0 d-flex align-items-stretch mb-lg-0 mb-4">
+                                          <div class="timeline-box shadow">
+                                              <li>
+                                                  {{ if .link }}
+                                                  <a href="{{ .link }}" class="talk-link">
+                                                  {{ end }}
+                                                    <h3 class="timeline-head text-white">{{ .title }}</h3>
+                                                  {{ if .link }}
+                                                  </a>
+                                                  {{ end }}
+                                                  <h6 class="yellow-text pt-md-3">{{ .speaker }}</h6>
+                                              </li>
+                                          </div>
+                                      </div>
+                                    {{ else if (eq .type "talk") }}
+                                      <div
+                                          class="col-lg-3 col-12 ps-0 d-flex align-items-stretch mb-lg-0 mb-4">
                                           <div class="timeline-box shadow">
                                               <li>
                                                   {{ if .link }}
@@ -74,6 +90,11 @@
                   </div>
                   {{ end }}
               </div>
+              {{ if .extend }}
+                <p class="schedule-para text-grey pt-md-3">
+                    {{ .extend | safeHTML }} 
+                </p>
+              {{ end }}
           </div>
       </div>
   </div>

--- a/layouts/partials/sections/schedule.html
+++ b/layouts/partials/sections/schedule.html
@@ -31,12 +31,12 @@
                           <ul class="timeline">
                               {{ range $i, $elem := .schedule }}
                               <div class="row event {{ if (ne $i 0) }}mt-2{{ end }}" data-date="{{ .time }}">
-                                  {{ range .talks }}
+                                  {{ range $t_index, $elem := .talks }}
                                     {{ if (eq .type "workshop") }}
                                       <div
                                           class="col-lg-4 col-12 ps-0 d-flex align-items-stretch mb-lg-0 mb-4">
                                           <div class="timeline-box shadow">
-                                              <li>
+                                              <li class="d-flex flex-column" style="height: 100%">
                                                   {{ if .link }}
                                                   <a href="{{ .link }}" class="talk-link">
                                                   {{ end }}
@@ -45,6 +45,16 @@
                                                   </a>
                                                   {{ end }}
                                                   <h6 class="yellow-text pt-md-3">{{ .speaker }}</h6>
+                                                  <p class="location">
+                                                    Room: 
+                                                    <span>
+                                                        {{ if .room }}
+                                                            {{ .room }}
+                                                        {{ else }}
+                                                            Stage {{ add $t_index 1 }}
+                                                        {{ end }}
+                                                    </span>
+                                                  </p>
                                               </li>
                                           </div>
                                       </div>
@@ -52,7 +62,7 @@
                                       <div
                                           class="col-lg-3 col-12 ps-0 d-flex align-items-stretch mb-lg-0 mb-4">
                                           <div class="timeline-box shadow">
-                                              <li>
+                                              <li class="d-flex flex-column" style="height: 100%">
                                                   {{ if .link }}
                                                   <a href="{{ .link }}" class="talk-link">
                                                   {{ end }}
@@ -61,6 +71,17 @@
                                                   </a>
                                                   {{ end }}
                                                   <h6 class="yellow-text pt-md-3">{{ .speaker }}</h6>
+
+                                                  <p class="location">
+                                                      Room: 
+                                                        <span>
+                                                            {{ if .room }}
+                                                                {{ .room }}
+                                                            {{ else }}
+                                                                Stage {{ add $t_index 1 }}
+                                                            {{ end }}
+                                                        </span>
+                                                  </p>
                                               </li>
                                           </div>
                                       </div>

--- a/layouts/partials/sections/schedule.html
+++ b/layouts/partials/sections/schedule.html
@@ -63,7 +63,6 @@
                                                   <h6 class="yellow-text pt-md-3">{{ .speaker }}</h6>
 
                                                   <p class="location">
-                                                      Room: 
                                                         <span>
                                                             {{ if .room }}
                                                                 {{ .room }}
@@ -103,7 +102,7 @@
               </div>
               {{ if .extend }}
                 <p class="schedule-para extend-info text-grey pt-md-3">
-                    {{ .extend | safeHTML }} 
+                    {{ .extend | safeHTML }}
                 </p>
               {{ end }}
           </div>

--- a/layouts/partials/sections/schedule.html
+++ b/layouts/partials/sections/schedule.html
@@ -45,16 +45,6 @@
                                                   </a>
                                                   {{ end }}
                                                   <h6 class="yellow-text pt-md-3">{{ .speaker }}</h6>
-                                                  <p class="location">
-                                                    Room: 
-                                                    <span>
-                                                        {{ if .room }}
-                                                            {{ .room }}
-                                                        {{ else }}
-                                                            Stage {{ add $t_index 1 }}
-                                                        {{ end }}
-                                                    </span>
-                                                  </p>
                                               </li>
                                           </div>
                                       </div>
@@ -112,7 +102,7 @@
                   {{ end }}
               </div>
               {{ if .extend }}
-                <p class="schedule-para text-grey pt-md-3">
+                <p class="schedule-para extend-info text-grey pt-md-3">
                     {{ .extend | safeHTML }} 
                 </p>
               {{ end }}

--- a/layouts/schedule/single.html
+++ b/layouts/schedule/single.html
@@ -1,0 +1,10 @@
+{{ define "main"}}
+    <!-- schedule page section started -->
+
+    <!-- Schedule -->
+    {{ if .Site.Data.schedule.live }}
+        {{ partial "sections/schedule.html" (dict "schedules" .Site.Data.schedule.data "extend" .Site.Data.schedule.extend) }}
+    {{ end }}
+
+    <!-- about sub section ended -->
+{{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -525,6 +525,10 @@ a.yellow-text:focus {
   top: 0;
 }
 
+p.schedule-para.extend-info {
+  font-size: 1.75rem;
+}
+
 @media (max-width: 767px) {
   html, body {
     overflow-x: hidden!important;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -456,6 +456,18 @@ a.yellow-text:focus {
   color: #FFF;
 }
 
+.schedule-section .timeline .timeline-box p.location {
+  align-self:flex-end;
+  margin-top: auto;
+  padding-top: 1.5rem;
+  font-size: 0.85rem;
+  color: #cb7bff;
+}
+
+.schedule-section .timeline .timeline-box p.location span {
+  font-weight: 600;
+}
+
 .schedule-section .timeline .timeline-box a.talk-link:focus h3 {
   border: 1px solid;
 }


### PR DESCRIPTION
Things to be done by content edtors:
- **D & I Track**: As discussed with @raukadah, we will have the D & I (or whatever you decide to call it) track as the 4th track. So you need to go to `schedule.yml`, and for a particular date in the time slots which have a talk in that track, add a talk item as the very end item. For example, if you want to add a talk for 18th at 14:30, go to https://github.com/pythonindia/inpycon2021/blob/main/data/schedule.yml#L83-L101 and add after line 101, a talk item in the format:
```
- title: Talk Title
  speaker: Speaker name 
  type: talk
  link: <link to the talk>
  track: 4
```

- **Poster session**: As discussed with @raukadah, since all poster sessions are part of the Break time, just rewrite "Break/Networking" as "Break/Poster Session/Networking" or "Poster Session/Networking" or whatever you deem fit. And add a `link: <link to poster session>` in all break items in schedule.yml

- **.Extend track**: As part of this PR, I have added a `extend` key in schedule.yml which supports HTML. So you can edit the value of the `extend` key to the text you want and put the link you want as `<a class="text-decoration-none fw-bold  yellow-text white-hovertext" href="https://something"><link></a>`

PS: This should be merged after https://github.com/pythonindia/inpycon2021/pull/35/files and in that PR, the link in nav needs to be changed to `schedule/`, otherwise the schedule won't be discoverable, since I removed it from the homepage. Ideally merge both at the same time and then deploy. cc @palnabarun @anistark 