### PR TITLE
Add short schedule section on homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,7 +15,11 @@
         {{ partial "sections/ticket.html" (dict "tickets" .Site.Data.tickets.data) }}
     {{ end }}
 
-
+    <!-- Schedule -->
+    {{ if .Site.Data.schedule.live }}
+    {{ partial "sections/schedule-short.html" }}
+    {{ end }}
+    
     <!-- Outreach Partners -->
     {{ if .Site.Data.communities.live }}
         {{ partial "sections/community.html" (dict "communities" .Site.Data.communities.data "outreach_blog_link" .Site.Data.communities.outreach_blog_link "outreach_form_link" .Site.Data.communities.outreach_form_link) }}

--- a/layouts/partials/sections/schedule-short.html
+++ b/layouts/partials/sections/schedule-short.html
@@ -1,0 +1,20 @@
+<!-- short schedule section started -->
+<section class="schedule-section pb-5 pb-md-0" style="background-image: none;" id="schedule">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12 text-center pt-md-5">
+                <h1 class="schedule-head text-white fw-bold pt-5" data-aos="fade-left" data-aos-duration="5000">
+                    Schedule</h1>
+                    <p class="schedule-para text-grey pt-md-3">PyCon India 2021 schedule has been released!</p>
+                <a href="schedule/" class="yellow-text white-hovertext text-decoration-none fw-bold">Check out the schedule <i
+                        class="fas fa-chevron-circle-right"></i></a>
+                
+                <div class="tab-content mt-md-5 pb-md-5" id="pills-tabContent">
+                </div>
+ 
+            </div>
+        </div>
+    </div>
+  </section>
+  <!-- short schedule section ended -->
+  


### PR DESCRIPTION
This will help people in leading them back to the main schedule page especially on mobile where the navbar is hidden behind a burger menu and people expected to see a schedule somewhere on the page. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
